### PR TITLE
Start Next.js migration scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+out/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@
 
 ---
 
+## Next.js への移行について
+現在、Next.js への移行を開始しました。`output: 'export'` により GitHub Pages 向けの静的エクスポート運用を前提に構成しています。
+
+### ローカル開発
+```bash
+npm install
+npm run dev
+```
+
+### 静的エクスポート（GitHub Pages 用）
+```bash
+npm run build
+npm run export
+```
+
+---
+
 ## 主な機能
 1. **ヒートマップの描画**  
    - 最適化対象の関数をヒートマップとして可視化。

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+  images: {
+    unoptimized: true,
+  },
+  basePath: '/gradient_descent_playground',
+  assetPrefix: '/gradient_descent_playground',
+  trailingSlash: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "gradient-descent-playground",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "export": "next export",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "typescript": "5.5.4"
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import '../styles/globals.css';
+
+export const metadata: Metadata = {
+  title: 'Gradient Descent Playground',
+  description: '勾配法の挙動を可視化するインタラクティブなプレイグラウンド。',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ja">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,42 @@
+export default function Home() {
+  return (
+    <main className="page">
+      <header className="hero">
+        <div>
+          <p className="eyebrow">Migration kickoff</p>
+          <h1>Gradient Descent Playground</h1>
+          <p className="subtitle">
+            Next.js への移行プロジェクトを開始しました。ここから UI の刷新と
+            ブログ機能の追加を進めます。
+          </p>
+          <div className="actions">
+            <a className="primary" href="/gradient_descent_playground/index.html">
+              既存デモを見る
+            </a>
+            <a className="secondary" href="#roadmap">
+              進行ロードマップ
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <section className="card" id="roadmap">
+        <h2>移行ロードマップ（初期）</h2>
+        <ol>
+          <li>現行の可視化ロジックを core モジュールとして切り出し</li>
+          <li>UI をコンポーネント化して操作性を改善</li>
+          <li>ブログ機能（Markdown/MDX）を追加</li>
+          <li>ユーザー定義の目的関数・最適化手法を実行可能に</li>
+        </ol>
+      </section>
+
+      <section className="card">
+        <h2>次のステップ</h2>
+        <ul>
+          <li>現在の JS を TypeScript 化して段階的に移植</li>
+          <li>GitHub Pages 向けの静的エクスポート運用を整備</li>
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,113 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f4f9;
+  --text: #1f1f1f;
+  --primary: #2846aa;
+  --primary-dark: #1b2f73;
+  --card: #ffffff;
+  --border: #e3e7f1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Helvetica", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 48px 20px 64px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero {
+  background: linear-gradient(135deg, #8ec5fc 0%, #e0c3fc 100%);
+  color: #0f172a;
+  padding: 40px;
+  border-radius: 20px;
+  box-shadow: 0 14px 40px rgba(15, 23, 42, 0.15);
+}
+
+.hero h1 {
+  margin: 8px 0 12px;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0 0 24px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.actions a {
+  text-decoration: none;
+  padding: 10px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.primary {
+  background: var(--primary);
+  color: #ffffff;
+}
+
+.primary:hover {
+  background: var(--primary-dark);
+}
+
+.secondary {
+  background: #ffffff;
+  color: var(--primary-dark);
+  border: 1px solid var(--border);
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+ol,
+ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 28px;
+  }
+
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Begin migrating the project to Next.js to enable a componentized UI, add blog/MDX support later, and support GitHub Pages via static export.
- Provide a minimal app shell and developer workflow so subsequent incremental TypeScript migrations and feature work can proceed.

### Description
- Add a Next.js + TypeScript scaffold including `package.json`, `tsconfig.json`, and `next-env.d.ts` and configure static export and GitHub Pages paths in `next.config.js` (`output: 'export'`, `basePath`, `assetPrefix`, `trailingSlash`).
- Create a minimal app shell with `src/app/layout.tsx`, a migration kickoff landing `src/app/page.tsx`, and base styles in `src/styles/globals.css`.
- Add `.gitignore` for Node/Next output and update `README.md` with local development (`npm install` / `npm run dev`) and static export (`npm run build` / `npm run export`) instructions.

### Testing
- Ran `npm install` in the project, which failed with a `403 Forbidden` error from the npm registry so dependencies could not be installed and the dev server could not be started.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb25031d0832aab583b09c40e6271)